### PR TITLE
sv/eth0: make sure eth0 interface is up

### DIFF
--- a/ignite/etc/sv/eth0/run
+++ b/ignite/etc/sv/eth0/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+ifconfig eth0 up
 exec dhcpcd -qLB -t 0 eth0


### PR DESCRIPTION
this could also be done as

```
ip link set dev eth0 up
```

not sure which is more standard.
`ip` belongs to [`iproute2`](http://www.linuxfoundation.org/collaborate/workgroups/networking/iproute2)
`ifconfig` belongs to [`net-tools`](http://net-tools.sourceforge.net/)
