### PR TITLE
Change nginx service to point to new binary location

### DIFF
--- a/ignite/etc/sv/nginx/run
+++ b/ignite/etc/sv/nginx/run
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec /usr/sbin/nginx -g 'daemon off;' 2>&1
+exec /usr/bin/nginx -g 'daemon off;' 2>&1


### PR DESCRIPTION
nginx was moved from /usr/sbin/nginx to /usr/bin/nginx in a recent update
