### PR TITLE
Make ntpd service work without conf.d/ntpd.conf

### DIFF
--- a/ignite/etc/sv/ntpd/run
+++ b/ignite/etc/sv/ntpd/run
@@ -1,4 +1,2 @@
 #!/bin/sh
-. /etc/conf.d/ntpd.conf
-
-exec ntpd $NTPD_ARGS -n 2>&1
+exec ntpd -g -u ntp:ntp -n 2>&1


### PR DESCRIPTION
/etc/conf.d/ntpd.conf no longer exists, so adjust the ntpd service to use
the arguments that /usr/lib/systemd/system/ntpd.service uses
